### PR TITLE
Add specific version to migration

### DIFF
--- a/db/migrate/20151202061645_create_authors.rb
+++ b/db/migrate/20151202061645_create_authors.rb
@@ -1,4 +1,4 @@
-class CreateAuthors < ActiveRecord::Migration
+class CreateAuthors < ActiveRecord::Migration[7.1]
   def change
     create_table :authors do |t|
       t.string :name

--- a/db/migrate/20151202061742_create_posts.rb
+++ b/db/migrate/20151202061742_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
       t.string :title


### PR DESCRIPTION
This pull request updates the migration files to specify the Rails migration version. This ensures compatibility with Rails 7.1 and helps prevent potential issues when running migrations in newer Rails environments.

Migration versioning updates:

* Updated `CreateAuthors` migration to inherit from `ActiveRecord::Migration[7.1]` instead of the generic `ActiveRecord::Migration`.
* Updated `CreatePosts` migration to inherit from `ActiveRecord::Migration[7.1]` instead of the generic `ActiveRecord::Migration`.