### PR TITLE
Add Validations to Post and Author

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,2 +1,4 @@
 class Author < ApplicationRecord
+  validates :name, presence: true, uniqueness:  true
+  validates :phone_number, length: {minimum: 10}
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,8 @@
 class Post < ApplicationRecord
+  include ActiveModel::Validations
   validates :title, presence: true
   validates :content, presence: true, length: {minimum: 250}
   validates :summary, presence: true, length: {maximum: 250}
   validates :category, inclusion: { in: %w(Fiction Non-Fiction)}
+  validates_with TitleValidator
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,6 @@
 class Post < ApplicationRecord
+  validates :title, presence: true
+  validates :content, presence: true, length: {minimum: 250}
+  validates :summary, presence: true, length: {maximum: 250}
+  validates :category, inclusion: { in: %w(Fiction Non-Fiction)}
 end

--- a/app/validators/title_validator.rb
+++ b/app/validators/title_validator.rb
@@ -1,0 +1,14 @@
+class TitleValidator < ActiveModel::Validator
+  def validate(record)
+    unless record.title && includes_clickbait?(record.title)
+      record.errors.add(:title, "Not Click-baity Enough")
+    end
+  end
+
+  private
+
+  def includes_clickbait?(title)
+    phrases = ["Won't Believe", "Secret", "Top", "Guess"]
+    phrases.any? { |phrase| title.include?(phrase) }
+  end
+end

--- a/db/migrate/20151202061645_create_authors.rb
+++ b/db/migrate/20151202061645_create_authors.rb
@@ -1,4 +1,4 @@
-class CreateAuthors < ActiveRecord::Migration
+class CreateAuthors < ActiveRecord::Migration[7.1]
   def change
     create_table :authors do |t|
       t.string :name

--- a/db/migrate/20151202061742_create_posts.rb
+++ b/db/migrate/20151202061742_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[7.1]
   def change
     create_table :posts do |t|
       t.string :title


### PR DESCRIPTION
This pull request adds validations to the `Author` and `Post` models to ensure data integrity and introduces a custom validator for post titles. It also updates migration files to specify the Rails version for compatibility.

Model validations:

* Added presence and uniqueness validations for `name`, and a minimum length validation for `phone_number` in the `Author` model.
* Added presence, length, and inclusion validations for `title`, `content`, `summary`, and `category` in the `Post` model. Also included the custom `TitleValidator`.

Custom validator:

* Implemented `TitleValidator` to ensure post titles include clickbait phrases such as "Won't Believe", "Secret", "Top", or "Guess".

Migration updates:

* Updated `CreateAuthors` and `CreatePosts` migration classes to inherit from `ActiveRecord::Migration[7.1]` for Rails 7.1 compatibility. [[1]](diffhunk://#diff-d285fdb407ca72f3e9b0e552ef61709aabaa2833a59a2b8f2bda9731e4fdec01L1-R1) [[2]](diffhunk://#diff-ae5c849b9995a518e539466dc3712b4884bfcb32ac209267e7bfcbae4e227444L1-R1)